### PR TITLE
🐛 [Bug] 한국어 입력 응답 처리 해결 

### DIFF
--- a/src/main/java/hanaon/AiAssistant/service/TranslationService.java
+++ b/src/main/java/hanaon/AiAssistant/service/TranslationService.java
@@ -1,0 +1,58 @@
+package hanaon.AiAssistant.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.nio.charset.Charset;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+public class TranslationService {
+
+    @Value("${deepl.api.key}")
+    private String apiKey;
+
+    @Autowired
+    private TextGenerationService textGenerationService;  // 텍스트 생성 서비스 주입
+
+    public String translateText(String text, String sourceLang, String targetLang) {
+        RestTemplate restTemplate = new RestTemplate();
+        String url = "https://api-free.deepl.com/v2/translate";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(new MediaType("application", "x-www-form-urlencoded", Charset.forName("UTF-8")));
+//        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
+        headers.set("Authorization", "DeepL-Auth-Key " + apiKey);
+
+        String body = "text=" + text + "&source_lang=" + sourceLang + "&target_lang=" + targetLang;
+        HttpEntity<String> entity = new HttpEntity<>(body, headers);
+
+        ResponseEntity<String> response = restTemplate.postForEntity(url, entity, String.class);
+
+        // TODO: JSON 파싱 추가
+        return response.getBody();
+    }
+
+    public String processRequest(String prompt) throws Exception {
+        // 한국어 입력을 영어로 번역
+        String translatedToEnglish = translateText(prompt, "KO", "EN");
+        System.out.println("translatedToEnglish = " + translatedToEnglish);
+
+        // 영어로 GPT-3 응답 생성
+        String generatedText = textGenerationService.generateText(translatedToEnglish);
+        System.out.println("Generated text: " + generatedText);
+
+        // 생성된 응답 리턴
+        return generatedText;
+//        return translateText(generatedText, "EN", "KO");
+    }
+}

--- a/src/main/java/hanaon/AiAssistant/web/controller/TranslateController.java
+++ b/src/main/java/hanaon/AiAssistant/web/controller/TranslateController.java
@@ -1,0 +1,25 @@
+package hanaon.AiAssistant.web.controller;
+
+import hanaon.AiAssistant.service.TranslationService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/translate")
+public class TranslateController {
+
+    @Autowired
+    private TranslationService translationService;
+
+    // POST 메서드를 사용하여 텍스트 생성 요청을 처리합니다.
+    @PostMapping
+    public String translateText(@RequestParam("text") String text) {
+        try {
+            // TranslationService의 processRequest 메서드 호출
+            return translationService.processRequest(text);
+        } catch (Exception e) {
+            // 예외 발생 시 에러 메시지 반환
+            return "Error during translation: " + e.getMessage();
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,3 +3,10 @@ openai.api.key=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
 
 spring.security.user.name=user
 spring.security.user.password=password
+
+deepl.api.url=https://api-free.deepl.com/v2/translate
+deepl.api.key=5c880a7a-c3a4-48e0-9043-1ff8654dcaab:fx
+
+server.servlet.encoding.charset=UTF-8
+server.servlet.encoding.enabled=true
+server.servlet.encoding.force=true

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -7,12 +7,12 @@
             const prompt = document.getElementById('prompt').value;
 
             try {
-                const response = await fetch('/api/text/generate', {
+                const response = await fetch('/api/translate', {
                     method: 'POST',
                     headers: {
-                        'Content-Type': 'application/json'
+                        'Content-Type': 'application/x-www-form-urlencoded'
                     },
-                    body: JSON.stringify({ prompt })
+                    body: `text=${encodeURIComponent(prompt)}`
                 });
 
                 if (response.ok) {


### PR DESCRIPTION
## 🐛 버그 처리 과정

1. 한국어 질문 입력
2. DeepL API 사용하여 한국어 입력을 영어로 번역
3. Open AI API 사용하여 한국어로 된 응답 생성
<br>

## 🔫 트러블 슈팅
### 이슈
입력된 한국어가 서버로 보내질 때 ???로 깨져서 보인다.

### 해결
POST 요청을 통해 body를 받을 때, encodeURIComponent를 사용해서 받아주고,
application.properties에 다음 코드를 추가해주었다.

```
server.servlet.encoding.charset=UTF-8
server.servlet.encoding.enabled=true
server.servlet.encoding.force=true
```
